### PR TITLE
Enable adding multiple homekit-ratgdo's to HomeKit

### DIFF
--- a/src/homekit.cpp
+++ b/src/homekit.cpp
@@ -5,6 +5,10 @@
 #include "ratgdo.h"
 #include "comms.h"
 #include "log.h"
+#include <ESP8266WiFi.h>
+
+#define DEVICE_NAME_SIZE 19
+#define SERIAL_NAME_SIZE 18
 
 // Bring in config and characteristics defined in homekit_decl.c
 extern "C" homekit_server_config_t config;
@@ -23,6 +27,12 @@ void target_door_state_set(const homekit_value_t new_value);
 homekit_value_t obstruction_detected_get();
 homekit_value_t active_state_get();
 
+// Make device_name available
+extern "C" char device_name[DEVICE_NAME_SIZE];
+
+// Make serial_number available
+extern "C" char serial_number[SERIAL_NAME_SIZE];
+
 /********************************** MAIN LOOP CODE *****************************************/
 
 void homekit_loop() {
@@ -30,6 +40,9 @@ void homekit_loop() {
 }
 
 void setup_homekit() {
+    snprintf(device_name, DEVICE_NAME_SIZE, "Garage Door %06X", ESP.getChipId());
+    String macAddress = WiFi.macAddress();
+    snprintf(serial_number, SERIAL_NAME_SIZE, "%s", macAddress.c_str());
 
     current_door_state.getter = current_door_state_get;
     target_door_state.getter = target_door_state_get;

--- a/src/homekit_decl.c
+++ b/src/homekit_decl.c
@@ -24,6 +24,9 @@ void identify(homekit_value_t _value) {
     printf("accessory identify\n");
 }
 
+char device_name[19];
+char serial_number[18];
+
 homekit_characteristic_t active_state = HOMEKIT_CHARACTERISTIC_(
         STATUS_ACTIVE, false,
         );
@@ -51,9 +54,9 @@ homekit_characteristic_t obstruction_detected = HOMEKIT_CHARACTERISTIC_(
 homekit_accessory_t *accessories[] = {
     HOMEKIT_ACCESSORY(.id=1, .category=homekit_accessory_category_garage, .services=(homekit_service_t*[]){
             HOMEKIT_SERVICE(ACCESSORY_INFORMATION, .characteristics=(homekit_characteristic_t*[]){
-                    HOMEKIT_CHARACTERISTIC(NAME, "Garage Door"),
+                    HOMEKIT_CHARACTERISTIC(NAME, device_name),
                     HOMEKIT_CHARACTERISTIC(MANUFACTURER, "ratCloud llc"),
-                    HOMEKIT_CHARACTERISTIC(SERIAL_NUMBER, "123456"),
+                    HOMEKIT_CHARACTERISTIC(SERIAL_NUMBER, serial_number),
                     HOMEKIT_CHARACTERISTIC(MODEL, "ratgdo"),
                     HOMEKIT_CHARACTERISTIC(FIRMWARE_REVISION, AUTO_VERSION),
                     HOMEKIT_CHARACTERISTIC(IDENTIFY, identify),


### PR DESCRIPTION
It wasn't possible to add more than one homekit-ratgdo device to HomeKit because `HOMEKIT_CHARACTERISTIC(NAME)` was not unique. This change adds a unique name based on `ESP.getChipID()`