### PR TITLE
Passing NULL to a pointer arg.

### DIFF
--- a/src/comms.cpp
+++ b/src/comms.cpp
@@ -383,7 +383,8 @@ uint32_t read_counter_from_flash(const char* filename) {
     if (!file) {
         RINFO("%s doesn't exist. creating...", filename);
 
-        write_counter_to_flash(filename, 0);
+        uint32_t count = 0;
+        write_counter_to_flash(filename, &count);
         return 0;
     }
 


### PR DESCRIPTION
I never saw a null pointer deference error, but this was picked up by the PIO inspector