### PR TITLE
Remote syslog.- DO NOT MERGE

### DIFF
--- a/lib/ratgdo/log.h
+++ b/lib/ratgdo/log.h
@@ -10,10 +10,16 @@ void print_packet(uint8_t pkt[SECPLUS2_CODE_LEN]);
 
 #ifndef UNIT_TEST
 
+#include <Syslog.h>
+extern Syslog syslog;
+#define RINFO(message, ...) syslog.logf(LOG_INFO, ">>> [%7d] RATGDO: " message "\r\n", millis(), ##__VA_ARGS__)
+#define RERROR(message, ...) syslog.logf(LOG_ERR, "!!! [%7d] RATGDO: " message "\r\n", millis(), ##__VA_ARGS__)
+/*
 #include <esp_xpgm.h>
 
 #define RINFO(message, ...) XPGM_PRINTF(">>> [%7d] RATGDO: " message "\r\n", millis(), ##__VA_ARGS__)
 #define RERROR(message, ...) XPGM_PRINTF("!!! [%7d] RATGDO: " message "\r\n", millis(), ##__VA_ARGS__)
+*/
 
 #else  // UNIT_TEST
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -27,6 +27,7 @@ lib_deps =
     https://github.com/mrthiti/Arduino-HomeKit-ESP8266.git#fix-conflict-base64-file-name
     esphome/Improv@^1.2.3
     https://github.com/ratgdo/espsoftwareserial.git#autobaud
+    arcao/Syslog@^2.0.0
 lib_ldf_mode = deep+
 extra_scripts =
     pre:auto_firmware_version.py
@@ -39,3 +40,4 @@ build_unflags = -std=gnu++11
 build_flags = -std=gnu++2a -Ilib/secplus/src -Wswitch-enum
 lib_ldf_mode = chain+
 debug_test = test_packet
+lib_deps = arcao/Syslog@^2.0.0

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -5,10 +5,22 @@
 
 #include "log.h"
 #include "secplus2.h"
+#include "wifi.h"
 
 #ifndef UNIT_TEST
 
 #include <Arduino.h>
+#include <WiFiUdp.h>
+
+#define SYSLOG_SERVER "syslog"
+#define SYSLOG_PORT 514
+
+#define DEVICE_HOSTNAME "ratgdo"
+#define APP_NAME "ratgdo"
+
+WiFiUDP udpClient;
+
+Syslog syslog(udpClient, SYSLOG_SERVER, SYSLOG_PORT, DEVICE_HOSTNAME, APP_NAME, LOG_KERN);
 
 void print_packet(uint8_t pkt[SECPLUS2_CODE_LEN]) {
     RINFO("decoded packet: [%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X]",


### PR DESCRIPTION
Setup a syslog server that accepts UDP messages on port 514  and make sure you have a DNS record 'syslog' pointing to it.

Logging works great.  You don't see the messages from HomeKit library yet.  Unfortunately this caused my GDO to go unresponsive in HK although I could still control it.  