### PR TITLE
Send a get status packet after toggling the lights

### DIFF
--- a/src/comms.cpp
+++ b/src/comms.cpp
@@ -371,6 +371,7 @@ void set_light(bool value) {
     PacketAction pkt_ac = {pkt, true};
 
     q_push(&pkt_q, &pkt_ac);
+    send_get_status();
 }
 
 


### PR DESCRIPTION
The local light state is not updated when turning on/off via HomeKit, this causes subsequent external light events (from keypad or motion) to be missed and not reported to Homekit.