### PR TITLE
Build Using GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,80 @@
+name: Build Firmware - PlatformIO CI
+
+on:
+  repository_dispatch:
+    types: [build-firmware]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Tag
+        id: tag
+        uses: JinoArch/get-latest-tag@latest
+
+      - uses: actions/checkout@v3
+        with:
+            submodules: secplus
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Install PlatformIO Core
+        run: |
+            pip install --upgrade pip
+            pip install --upgrade platformio
+
+      - name: Install External Dependencies
+        run: |
+          cd lib
+          git clone https://github.com/argilo/secplus.git
+
+      - name: Build PlatformIO Project
+        run: pio run -e ratgdo_esp8266_hV25
+
+      - name: Rename Firmware
+        run: |
+          mv .pio/build/ratgdo_esp8266_hV25/firmware.bin .pio/build/ratgdo_esp8266_hV25/homekit-ratgdo-${{ steps.tag.outputs.latestTag }}.bin
+          mv .pio/build/ratgdo_esp8266_hV25/firmware.elf .pio/build/ratgdo_esp8266_hV25/homekit-ratgdo-${{ steps.tag.outputs.latestTag }}.elf
+
+      - name: Attach Bundle
+        uses: AButler/upload-release-assets@v3.0
+        with:
+          files: ".pio/build/ratgdo_esp8266_hV25/*.bin"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          release-tag: ${{ steps.tag.outputs.latestTag }}
+      
+      - name: Upload Release Asset
+        uses: wow-actions/download-upload@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          url: https://github.com/donavanbecker/homekit-ratgdo/releases/download/${{ steps.tag.outputs.latestTag }}/homekit-ratgdo-${{ steps.tag.outputs.latestTag }}.bin
+          dir: docs/firmware/
+          commit_message: "Add Latest Firmware: homekit-ratgdo-${{ steps.tag.outputs.latestTag }}.bin"
+    
+      - name: Upload Firmware.bin
+        uses: actions/upload-artifact@v4
+        with:
+          name: homekit-ratgdo-${{ steps.tag.outputs.latestTag }}.bin
+          path: |
+            .pio/build/ratgdo_esp8266_hV25/*.bin
+    
+      - name: Upload Firmware.elf
+        uses: actions/upload-artifact@v4
+        with:
+          name: homekit-ratgdo-${{ steps.tag.outputs.latestTag }}.elf
+          path: |
+            .pio/build/ratgdo_esp8266_hV25/*.elf
+
+      - name: Download Firmware.bin
+        uses: actions/download-artifact@v4
+        with:
+          name: homekit-ratgdo-${{ steps.tag.outputs.latestTag }}.bin
+          path: |
+            docs/firmware/

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -1,0 +1,74 @@
+name: Update Manifest
+
+on:
+ release:
+    types: [published]
+ workflow_dispatch:
+
+jobs:
+  manifest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Tag
+        id: tag
+        uses: JinoArch/get-latest-tag@latest
+
+      - name: Write version to manifest.json
+        uses: amochkin/action-json@v1
+        id: write_version
+        with:
+          mode: write
+          file: docs/manifest.json
+          property: version
+          value: ${{ steps.tag.outputs.latestTag }}
+          value_type: string
+          
+      - name: Output created (or overwritten) manifest.json
+        run: cat docs/manifest.json
+        shell: bash
+        
+      - name: Output read value of 'version' property
+        run: echo ${{ steps.write_version.outputs.value }}
+        shell: bash
+
+      - name: Write version to manifest.json
+        uses: amochkin/action-json@v1
+        id: builds_parts_path
+        with:
+          mode: write
+          file: docs/manifest.json
+          property: builds.0.parts.0.path
+          value: firmware/homekit-ratgdo-${{ steps.tag.outputs.latestTag }}.bin
+          value_type: string
+          
+      - name: Output created (or overwritten) manifest.json
+        run: cat docs/manifest.json
+        shell: bash
+        
+      - name: Output read value of 'version' property
+        run: echo ${{ steps.builds_parts_path.outputs.value }}
+        shell: bash
+
+      - name: Attach manifest.json
+        uses: AButler/upload-release-assets@v3.0
+        with:
+          files: "/home/runner/work/homekit-ratgdo/homekit-ratgdo/docs/manifest.json"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          release-tag: ${{ steps.tag.outputs.latestTag }}
+
+      - name: Upload Release manifest.json
+        uses: wow-actions/download-upload@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          url: https://github.com/donavanbecker/homekit-ratgdo/releases/download/${{ steps.tag.outputs.latestTag }}/manifest.json
+          dir: docs/
+          commit_message: "Add Update manifest.json for ${{ steps.tag.outputs.latestTag }}"
+
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          event-type: build-firmware

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .piolibdeps
 compile_commands.json
 __pycache__
+.vscode/*

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,6 @@
+The release process
+===
+
+Once a release is ready, all you have to do is create a GitHub Release and tag. Once that release is created it will kick off the `.github/workflows/build.yml` GitHub Action. This workflow will do all the work for you to get a new release out. It will create an updated manifest.json file with the new version from the tag that you ceated with the release. It will also create the firmware.bin file following the format of homekit-ratgdo-${{ latest-tag }}.bin"
+
+When the firmware and manifest.json is updated, this will automatically update the flasher page as the /docs folder is what the flasher page looks at so no need to update anything in this folder.


### PR DESCRIPTION
This is an example of the Build running and then attaching the firmware.bin file to the release: [donavanbecker/homekit-ratgdo-v0.7.0](https://github.com/donavanbecker/homekit-ratgdo/releases/tag/v0.7.0)

This is an example of the firmware.bin and firmware.elf being attached to the workflow run:
[Build Workflow](https://github.com/donavanbecker/homekit-ratgdo/actions/runs/7261739296)

A few approaches that we could use depending on how you want to handle this.

Currently I have it designed to only trigger on a create of a release.