### PR TITLE
Fix a few duplicate log messages

### DIFF
--- a/src/homekit.cpp
+++ b/src/homekit.cpp
@@ -109,7 +109,7 @@ homekit_value_t active_state_get() {
 }
 
 homekit_value_t current_lock_state_get() {
-    RINFO("get current door state: %d", garage_door.current_lock);
+    RINFO("get current lock state: %d", garage_door.current_lock);
 
     return HOMEKIT_UINT8_CPP(garage_door.current_lock);
 }

--- a/src/homekit.cpp
+++ b/src/homekit.cpp
@@ -115,7 +115,7 @@ homekit_value_t current_lock_state_get() {
 }
 
 homekit_value_t target_lock_state_get() {
-    RINFO("get target door state: %d", garage_door.target_lock);
+    RINFO("get target lock state: %d", garage_door.target_lock);
 
     return HOMEKIT_UINT8_CPP(garage_door.target_lock);
 }


### PR DESCRIPTION
A couple of log messages relating to the lock referenced the door instead. This fixes those up.

Fixes #61