### PR TITLE
Pull in main branch of mrthiti's Homekit library to get mdns fix

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -24,7 +24,7 @@ monitor_filters = esp8266_exception_decoder
 lib_deps =
 ; mixiaoxiao/HomeKit-ESP8266@^1.2.0
 ; unless/until https://github.com/Mixiaoxiao/Arduino-HomeKit-ESP8266/pull/183 is merged
-    https://github.com/mrthiti/Arduino-HomeKit-ESP8266.git#fix-conflict-base64-file-name
+    https://github.com/mrthiti/Arduino-HomeKit-ESP8266.git
     esphome/Improv@^1.2.3
     https://github.com/ratgdo/espsoftwareserial.git#autobaud
 lib_ldf_mode = deep+


### PR DESCRIPTION
Changing to the master branch picks up both of these fixes

fix: It base64 error if use with WifiManager
fix: the device is not work after reconnect wifi