### PR TITLE
Update Releasing Notes, & Enforce Version Pattern

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -1,9 +1,9 @@
 name: Update Manifest
 
 on:
- release:
-    types: [published]
- workflow_dispatch:
+  release:
+     types: [published]
+  workflow_dispatch:
 
 permissions:
   actions: write
@@ -21,6 +21,19 @@ jobs:
       - name: Tag
         id: tag
         uses: JinoArch/get-latest-tag@latest
+        
+      - name: Check Tag
+        id: check-tag
+        run: |
+          echo "Latest Tag: ${{ steps.tag.outputs.latestTag }}"
+          if [[ ${{ steps.tag.outputs.latestTag }} =~ ^v[0-9].[0-9].[0-9]$ ]]; then
+              echo "match=true" >> $GITHUB_OUTPUT
+          fi
+      - name: Match
+        if: steps.check-tag.outputs.match != 'true'
+        run: |
+          echo "Tag: ${{ steps.tag.outputs.latestTag }}, does not match the required format: v0.0.0"
+          exit 1
 
       - name: Write version to manifest.json
         uses: amochkin/action-json@v1

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,6 +1,8 @@
 The release process
 ===
 
-Once a release is ready, all you have to do is create a GitHub Release and tag. Once that release is created it will kick off the `.github/workflows/build.yml` GitHub Action. This workflow will do all the work for you to get a new release out. It will create an updated manifest.json file with the new version from the tag that you ceated with the release. It will also create the firmware.bin file following the format of homekit-ratgdo-${{ latest-tag }}.bin"
+Once a release is ready, all you have to do is create a GitHub Release and tag. Once that release is created it will kick off the `.github/workflows/manifest.yml` GitHub Action. This workflow will do all the work for you to get a new release out. It will create an updated manifest.json file with the new version from the tag that you ceated with the release. Once that workflow completes it then triggers another workflow, `.github/workflows/build.yml`, this workflow will create the firmware.bin file following the format of `homekit-ratgdo-${{ latest-tag }}.bin`.
 
 When the firmware and manifest.json is updated, this will automatically update the flasher page as the /docs folder is what the flasher page looks at so no need to update anything in this folder.
+
+Releases tag should be named v[0-9]+.[0-9]+.[0-9], example: `v0.7.0`. the workflows are designed to follows this pattern, if this pattern isn't followed then the workflow will stop.


### PR DESCRIPTION
Added more details to the releasing.md and also checked for the pattern of the release tag. If it doesn't follow the pattern then the workflow will stop

Don't merge if https://github.com/ratgdo/homekit-ratgdo/pull/57 is merged.