### PR TITLE
Settings changes for LwIP

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -16,11 +16,14 @@ board_build.filesystem = littlefs
 [env:ratgdo_esp8266_hV25]
 framework = arduino
 platform = espressif8266
+platform_packages =
+    framework-arduinoespressif8266 @ https://github.com/jgstroud/Arduino.git#maxrtx
 board = d1_mini
 board_build.ldscript = eagle.flash.4m2m.ld
 build_flags =
     ${env.build_flags}
     '-fconcepts-ts'
+    -D PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY_LOW_FLASH
 monitor_filters = esp8266_exception_decoder
 lib_deps =
     https://github.com/dkerr64/Arduino-HomeKit-ESP8266.git#469d55013f173927e96e5d4a881ec77fb4969fe7
@@ -32,11 +35,4 @@ extra_scripts =
     pre:build_web_content.py
     pre:auto_firmware_version.py
 
-[env:native]
-platform = native
-build_unflags = -std=gnu++11
-; the following is a hack. I don't know why LDF can't figure out that the secplus directory is
-; necessary
-build_flags = -std=gnu++2a -Ilib/secplus/src -Wswitch-enum
-lib_ldf_mode = chain+
-debug_test = test_packet
+


### PR DESCRIPTION
bounjour-hap sometimes sends massive fragmented mdns packets Change to the no-feature version of LwIP to  disable all fragmenting and reassembly of packets.

If the TCP client suddenly goes away, LwIP will continue to send TCP retries for about 30 minutes. This can consume up to about 4k of heap. Use a custom lwip library that sets max tcp retries to 2, which will quickly close the connection and free up memory in this scenerio.