### PR TITLE
Add check for pre-releases in firmware update dialog

### DIFF
--- a/src/comms.cpp
+++ b/src/comms.cpp
@@ -43,7 +43,7 @@ SecPlus2Reader reader;
 uint32_t id_code = 0;
 uint32_t rolling_code = 0;
 uint32_t last_saved_code = 0;
-#define MAX_CODES_WITHOUT_FLASH_WRITE 100
+#define MAX_CODES_WITHOUT_FLASH_WRITE 10
 
 /******************************* SECURITY 1.0 *********************************/
 

--- a/src/web.cpp
+++ b/src/web.cpp
@@ -986,11 +986,13 @@ void handle_update()
         // Error logged in _setUpdaterError
         server.send(400, F("text/plain"), _updaterError);
     }
+#ifdef CRC_CHECK
     else if (!ESP.checkFlashCRC())
     {
         // CRC error
         server.send(400, F("text/plain"), "Flash CRC check failed. Update aborted");
     }
+#endif
     else
     {
         RINFO("Upload complete, received firmware MD5: %s", Update.md5String().c_str());
@@ -1079,8 +1081,10 @@ void handle_firmware_upload()
     else if (_authenticatedUpdate && upload.status == UPLOAD_FILE_END && !_updaterError.length())
     {
         Serial.printf("\n"); // newline after last of the dot dot dots
+#ifdef CRC_CHECK
         if (ESP.checkFlashCRC())
         {
+#endif
             if (Update.end(true))
             { // true to set the size to the current progress
                 RINFO("Update Success, size: %zu, Rebooting...", upload.totalSize);
@@ -1089,12 +1093,14 @@ void handle_firmware_upload()
             {
                 _setUpdaterError();
             }
+#ifdef CRC_CHECK
         }
         else
         {
             Update.end();
             RERROR("Flash CRC check failed. Update aborted");
         }
+#endif
     }
     else if (_authenticatedUpdate && upload.status == UPLOAD_FILE_ABORTED)
     {

--- a/src/www/functions.js
+++ b/src/www/functions.js
@@ -217,9 +217,19 @@ async function checkVersion(progress) {
         return;
     }
     // make sure we have newest release first
-    const latest = releases.sort((a, b) => {
-        return Date.parse(b.created_at) - Date.parse(a.created_at);
-    })[0];
+    let prerelease = false;
+    if (document.getElementById("prerelease").checkVisibility()) {
+        // Firmware update dialog is visible
+        prerelease = document.getElementById("prerelease").checked;
+    }
+    const latest = releases
+        .sort((a, b) => {
+            return Date.parse(b.created_at) - Date.parse(a.created_at);
+        })
+        .find((obj) => {
+            // if prerelease allowed, select first object.  Else select first object that not a prerelease.
+            return (prerelease || !obj.prerelease);
+        });
     serverStatus.latestVersion = latest;
     console.log("Newest version: " + latest.tag_name);
     const asset = latest.assets.find((obj) => {

--- a/src/www/index.html
+++ b/src/www/index.html
@@ -314,6 +314,8 @@
             </tr>
           </table>
           <input type="button" value="Check for update" onclick="checkVersion('dotdot2');">
+          <input type="checkbox" id="prerelease" name="prerelease" value="no">
+          <span style="font-size: 0.8em;">Include pre-releases</span>
           <input type="button" value="Update" style="float: right;"
             onclick="return confirm('Update firmware from GitHub, are you sure? Do not close browser until complete.') && firmwareUpdate(true);">
         </fieldset>


### PR DESCRIPTION
The check for a new release on the main home page will NOT include check for pre-releases.

To check for pre-release you must open the firmware update dialog, select the checkbox, then click on the check for update button.

This way users are not notified of pre-releases automatically, but if you are in-the-know, you can check for and install them.