### PR TITLE
Continue to send SSEheartbeats during firmware update

### DIFF
--- a/src/www/functions.js
+++ b/src/www/functions.js
@@ -156,7 +156,7 @@ async function checkStatus() {
             clearTimeout(checkHeartbeat);
             checkHeartbeat = setTimeout(() => {
                 // if no message received since last check then close connection and try again.
-                console.log(`SSE timeout, no message received in 5 seconds. Last upTime: ${serverStatus.upTime} (${msToTime(serverStatus.upTime)})`);
+                console.log(`SSE timeout, no message received in 30 seconds. Last upTime: ${serverStatus.upTime} (${msToTime(serverStatus.upTime)})`);
                 evtSource.close();
                 delayStatusFn.push(setTimeout(checkStatus, 1000));
             }, 30000);


### PR DESCRIPTION
During firmware uploads we had suspended Server Sent Events (SSE) heartbeat messages.  If uploading on a slow connection, the browser client will timeout, shutting it down. I had thought the timeout was 5 seconds, turns out to be 30 seconds.

Solution was not as simple as just removing the test for `updateUnderway` in `SSEheartbeat()` function.  Turns out that during file upload nothing else runs... The main loop is not called, `Ticker` functions are not run, etc.  This explains why we had problems in the past with firmware uploads failing... as the HomeKit server was not getting called to process any HomeKit messages coming in.  We solved that by shutting down the HomeKit server before starting the upload.

So... I had to explicitly call the `SSEheartbeat()` function periodically during firmware uploads.  I do it on 10% increments, we should comfortably trigger this in under 30 seconds.