### PR TITLE
Fix ESP8266 alignment crash in force_recover struct access

### DIFF
--- a/src/comms.cpp
+++ b/src/comms.cpp
@@ -18,7 +18,7 @@
 
 /********************************** LOCAL STORAGE *****************************************/
 
-struct PacketAction
+struct __attribute__((aligned(4))) PacketAction
 {
     Packet pkt;
     bool inc_counter;

--- a/src/ratgdo.h
+++ b/src/ratgdo.h
@@ -67,7 +67,7 @@ struct GarageDoor
     LockTargetState target_lock;
 };
 
-struct ForceRecover
+struct __attribute__((aligned(4))) ForceRecover
 {
     uint8_t push_count;
     unsigned long timeout;


### PR DESCRIPTION
## Summary
- Fixes LoadStoreAlignmentCause (Exception 9) crashes on ESP8266
- Adds 4-byte alignment attributes to PacketAction and ForceRecover structs
- Resolves memory alignment issues when accessing multi-byte struct members

## Problem Details
The force_recover struct starts with push_count, which is a single byte (uint8_t). Right after it is timeout, which is four bytes (unsigned long).

When the compiler allocates memory for this struct, it might place push_count at an aligned address (e.g., 0x4000...0). This means timeout will start at the very next byte (0x4000...1), which is not a multiple of 4.

When the manual_recovery() function is called, it tries to read or write to force_recover.timeout. The processor attempts a 4-byte access at an unaligned address, which it cannot do. This triggers Exception (9), crashing the system.

## Solution
Added `__attribute__((aligned(4)))` to both PacketAction and ForceRecover struct definitions to ensure proper memory alignment.