### PR TITLE
fixes the mystery notifications of door changes,

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "homekit-ratgdo",
-  "version": "v1.9.0",
+  "version": "v1.9.1",
   "new_install_prompt_erase": true,
   "new_install_improv_wait_time": 60,
   "builds": [

--- a/src/comms.cpp
+++ b/src/comms.cpp
@@ -396,7 +396,7 @@ void comms_loop_sec1()
                 // best attempt to trap invalid values (due to collisions)
                 if (((val & 0xF0) != 0x00) && ((val & 0xF0) != 0x50) && ((val & 0xF0) != 0xB0))
                 {
-                    RINFO("0x38 val upper nible not 0x0 or 0x5 or 0xB: %02X", val);
+                    RINFO("DoorStatus(0x38) val upper nible not 0x0 or 0x5 or 0xB: %02X", val);
                     break;
                 }
 
@@ -545,10 +545,11 @@ void comms_loop_sec1()
 
                 // RINFO("0x3A MSG: %X%02X",key,val);
 
-                // upper nibble must be 5
-                if ((val & 0xF0) != 0x50)
+                // upper nibble must be 0x5 or 0x1
+                // MJS 8/20/2025 verifyed when door is obstucted for > 10 secs, BIT7 clears
+                if (((val & 0xF0) != 0x50) && ((val & 0xF0) != 0x10))
                 {
-                    RINFO("0x3A val upper nible not 5: %02X", val);
+                    RINFO("LightLockStatus(0x3A) \"value\" upper nibble not 0x5 or 0x1, received: 0x%02X", val);
                     break;
                 }
 

--- a/src/web.cpp
+++ b/src/web.cpp
@@ -245,7 +245,7 @@ struct SSESubscription
     IPAddress clientIP;
     WiFiClient client;
     Ticker heartbeatTimer;
-    float heartbeatInterval;
+    int heartbeatInterval;
     bool SSEconnected;
     int SSEfailCount;
     String clientUUID;
@@ -1421,11 +1421,11 @@ void handle_subscribe()
     }
 
     // validate optional heartbeat interval
-    float heartbeatInterval = 1.0;  // default
+    int heartbeatInterval = 1;  // default
     if (heartbeatIntervalArgIdx >= 0) {
-        float hbi = server.arg(heartbeatIntervalArgIdx).toFloat();
+        int hbi = server.arg(heartbeatIntervalArgIdx).toInt();
         // in range of 0 (no heartbeat) to 60 seconds
-        if (hbi < 0.0 || hbi > 60.00) {
+        if (hbi < 0 || hbi > 60) {
             RINFO("Invalid client for SSE subscription");
             server.send(400, "text/plain", "Invalid heartbeat interval (0 - 60)");
             return;
@@ -1436,7 +1436,7 @@ void handle_subscribe()
         }
     }
     if (heartbeatInterval > 0) {
-        RINFO("SSE Subscription for client %s has specified a heartbeat Interval of %2.1f seconds", server.arg(id).c_str(), heartbeatInterval);
+        RINFO("SSE Subscription for client %s has specified a heartbeat Interval of %d seconds", server.arg(id).c_str(), heartbeatInterval);
     }
     else {
         RINFO("SSE Subscription for client %s has specified a heartbeat disabled", server.arg(id).c_str());


### PR DESCRIPTION
went back to the must be 2 in-a-row matching values to confirm state changes on door status and light/lock status.
added in the discovery that if the sensors are obstructed for more than 10 seconds, bit7 clears in the light/lock status.
minor var type change for heartbeatInterval.

